### PR TITLE
Github Secrets for Google Drive keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,8 @@ venv.bak/
 db_config.py
 .vscode/settings.json
 config.json
+
+# files with secrets in them
+settings.yaml
+folder_id.txt
+credentials.json

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,0 +1,20 @@
+# This file allows authentication with Google Drive for the nimbus API
+# This enables uploading files to our Google Drive folder.
+# DO NOT upload this file (or credentials.json) to github or any other public directory
+# without removing access tokens and secrets!
+client_config_backend: settings
+client_config:
+  client_id: $CLIENT_ID
+  client_secret: $CLIENT_SECRET
+
+save_credentials: True
+save_credentials_backend: file
+save_credentials_file: credentials.json
+
+get_refresh_token: True
+
+oauth_scope:
+  - https://www.googleapis.com/auth/drive.file
+  - https://www.googleapis.com/auth/drive.install
+  - https://www.googleapis.com/auth/drive
+  - https://www.googleapis.com/auth/drive.metadata


### PR DESCRIPTION
## What's New?
This adds progress towards #15 by allowing us to use google drive API keys inside of github actions.  This also adds some files to the .gitignore so they don't accidentally end up on github with actual keys in them.
