### PR TITLE
Add endpoint to store scraped courses

### DIFF
--- a/Entity/Courses.py
+++ b/Entity/Courses.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, Enum
+from sqlalchemy import Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects.mysql import SET
 import enum

--- a/Entity/Courses.py
+++ b/Entity/Courses.py
@@ -22,7 +22,7 @@ class CollegeStanding(enum.Enum):
 class Courses(Base):
     __tablename__ = 'Courses'
     # TODO: update schema and this Courses class to follow snake_case convention
-    courseId = Column(String(10), primary_key=True)
+    id = Column(Integer, primary_key=True)
     dept = Column(String(5))
     courseNum = Column(Integer)
     termsOffered = Column(SET('F', 'W', 'SP', 'SU', 'TBD'))

--- a/Entity/Courses.py
+++ b/Entity/Courses.py
@@ -22,7 +22,7 @@ class CollegeStanding(enum.Enum):
 class Courses(Base):
     __tablename__ = 'Courses'
     # TODO: update schema and this Courses class to follow snake_case convention
-    courseId = Column(Integer, primary_key=True)
+    courseId = Column(String(10), primary_key=True)
     dept = Column(String(5))
     courseNum = Column(Integer)
     termsOffered = Column(SET('F', 'W', 'SP', 'SU', 'TBD'))
@@ -31,9 +31,6 @@ class Courses(Base):
     raw_concurrent_text = Column(Text)
     raw_recommended_text = Column(Text)
     raw_prerequisites_text = Column(Text)
-    crossListedAs = Column(String(45))
-    raw_standing_text = Column(String(45))
-    standing = Column(Enum(CollegeStanding))
 
     def __repr__(self):
         return "<Courses (dept={}, course_num={})>".format(

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -281,6 +281,27 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         self._create_database_session()
         print("initialized NimbusMySQLAlchemy")
 
+    @staticmethod
+    def validate_input_keys(input_data: dict, expected_keys: set):
+        if len(input_data) == 0:
+            msg = "expected: {} but got: {}"
+            msg = msg.format(expected_keys, set(input_data.keys()))
+            raise BadDictionaryKeyError(msg)
+
+        # assert that the formatted_data does not have extra keys
+        for k in input_data:
+            if k not in expected_keys:
+                msg = "expected: {} but got: {}"
+                msg = msg.format(expected_keys, set(input_data.keys()))
+                raise BadDictionaryKeyError(msg)
+
+        # assert that the keys_i_care_about are in formatted_data
+        for k in expected_keys:
+            if k not in input_data:
+                msg = "expected: {} but got: {}"
+                msg = msg.format(expected_keys, set(input_data.keys()))
+                raise BadDictionaryKeyError(msg)
+
     def _create_all_tables(self):
         # TODO: reconsider if this even works???
         # self.Base.metadata.create_all(self.engine)
@@ -355,25 +376,7 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
 
         print(formatted_data)
 
-        if len(formatted_data) == 0:
-            msg = "expected: {} but got: {}"
-            msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
-            raise BadDictionaryKeyError(msg)
-
-        # assert that the formatted_data does not have extra keys
-        for k in formatted_data:
-            if k not in keys_i_care_about:
-                msg = "expected: {} but got: {}"
-                msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
-                raise BadDictionaryKeyError(msg)
-
-        # assert that the keys_i_care_about are in formatted_data
-        for k in keys_i_care_about:
-            if k not in formatted_data:
-                msg = "expected: {} but got: {}"
-                msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
-                raise BadDictionaryKeyError(msg)
-
+        self.validate_input_keys(formatted_data, keys_i_care_about)
         # create an AudioSampleMetaData object with the given metadata
         metadata = AudioSampleMetaData()
 
@@ -419,6 +422,32 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         self.session.commit()
 
         pass
+
+    def save_course(self, course_data: dict):
+        expected_keys = {'courseId', 'dept', 'courseNum', 'units',
+                         'termsOffered', 'courseName', 'raw_concurrent_text',
+                         'raw_recommended_text', 'raw_prerequisites_text'}
+        self.validate_input_keys(course_data, expected_keys)
+
+        course = self.session.query(Courses).filter_by(courseId=course_data['courseId']).first()
+        if not course:
+            print("Adding new course: {}".format(course_data['courseId']))
+            course = Courses()
+            course.courseId = course_data['courseId']
+        else:
+            print("Updating course: {}".format(course_data['courseId']))
+
+        course.dept = course_data['dept']
+        course.courseNum = course_data['courseNum']
+        course.termsOffered = course_data['termsOffered']
+        course.units = course_data['units']
+        course.courseName = course_data['courseName']
+        course.raw_concurrent_text = course_data['raw_concurrent_text']
+        course.raw_recommended_text = course_data['raw_recommended_text']
+        course.raw_prerequisites_text = course_data['raw_prerequisites_text']
+
+        self.session.add(course)
+        self.session.commit()
 
     def _execute(self, query: str):
         return self.engine.execute(query)

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -424,18 +424,42 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         pass
 
     def save_course(self, course_data: dict):
-        expected_keys = {'courseId', 'dept', 'courseNum', 'units',
+        """
+        Save the course into the NimbusDatabase.
+
+        course_data this point looks like:
+        {
+            "dept": CPE,
+            "courseNum": 357,
+            "units": 4,
+            "termsOffered": "F,W,SP",
+            "courseName": "Systems Programming",
+            "raw_concurrent_text": "N/A",
+            "raw_recommended_text": "N/A",
+            "raw_prerequisites_text": "CSC/CPE,102,and,CSC/CPE,103,with,..."
+        }
+
+        Raises:
+            BadDictionaryKeyError - ...
+            BadDictionaryValueError - ...
+
+        Returns:
+            True if all is good, else False
+        """
+        expected_keys = {'dept', 'courseNum', 'units',
                          'termsOffered', 'courseName', 'raw_concurrent_text',
                          'raw_recommended_text', 'raw_prerequisites_text'}
         self.validate_input_keys(course_data, expected_keys)
 
-        course = self.session.query(Courses).filter_by(courseId=course_data['courseId']).first()
+        course = self.session.query(Courses).filter_by(dept=course_data['dept'],
+                                                       courseNum=course_data['courseNum']).first()
         if not course:
-            print("Adding new course: {}".format(course_data['courseId']))
+            print("Adding new course: {} {}".format(course_data['dept'],
+                                                    course_data['courseNum']))
             course = Courses()
-            course.courseId = course_data['courseId']
         else:
-            print("Updating course: {}".format(course_data['courseId']))
+            print("Updating course: {} {}".format(course_data['dept'],
+                                                  course_data['courseNum']))
 
         course.dept = course_data['dept']
         course.courseNum = course_data['courseNum']

--- a/flask_api.py
+++ b/flask_api.py
@@ -115,6 +115,9 @@ def save_a_recording():
 
 @app.route('/new_data/courses', methods=['POST'])
 def save_courses():
+    """
+    Persists list of courses
+    """
     data = json.loads(request.get_json())
     db = NimbusMySQLAlchemy(config_file=CONFIG_FILE_PATH)
     for course in data['courses']:

--- a/flask_api.py
+++ b/flask_api.py
@@ -3,6 +3,8 @@
 
 Contains all the handlers for the API. Also the main code to run Flask.
 """
+import json
+
 from flask import Flask, jsonify, request
 from flask_cors import CORS
 from pydrive.auth import GoogleAuth
@@ -109,6 +111,28 @@ def save_a_recording():
         raise e
 
     return filename
+
+
+@app.route('/new_data/courses', methods=['POST'])
+def save_courses():
+    data = json.loads(request.get_json())
+    db = NimbusMySQLAlchemy(config_file=CONFIG_FILE_PATH)
+    for course in data['courses']:
+        try:
+            db.save_course(course)
+        except BadDictionaryKeyError as e:
+            return str(e), BAD_REQUEST
+        except BadDictionaryValueError as e:
+            return str(e), BAD_REQUEST
+        except NimbusDatabaseError as e:
+            return str(e), BAD_REQUEST
+        except Exception as e:
+            # TODO: consider security tradeoff of displaying internal server errors
+            #       versus development time (being able to see errors quickly)
+            # HINT: security always wins
+            raise e
+
+    return "SUCCESS"
 
 
 def create_filename(form):


### PR DESCRIPTION
## What's New?
* `save_courses` API accepts a JSON object containing a list of all scraped courses (`request.form` did not play nicely with lists)
* `courseId` is now a string to uniquely identify each course (e.g. `CSC 101`)
* `validate_input_keys()` pulled out to its own function to be reused


## Fixes #46 

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Integration test with course scraper stores all scraped courses in local `MySQL` instance.

### Steps
1. Ensure your local connection to `MySQL`
2. Clone `https://github.com/calpoly-csai/csai-scraping`
3. Run `flask_api.py` in `api` package
4. Run `sustainer.py` in `csai-scraping` package (optionally comment out other scrapers if you do not want them to run) ([branch with updated `csai-scraping`](https://github.com/austinsilveria/course-web-scraper/tree/courseendpoint))


## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [x] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [x] I ran `./format.sh` because it automatically cleans my code for me 😄

- [x] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
