### PR TITLE
added script and emphasis to audio sample payload

### DIFF
--- a/Entity/AudioSampleMetaData.py
+++ b/Entity/AudioSampleMetaData.py
@@ -26,6 +26,8 @@ class AudioSampleMetaData(Base):
     tone = Column(String(255))
     timestamp = Column(Integer)
     username = Column(String(255))
+    script = Column(String(1024))
+    emphasis = Column(String(255))
     # Text chosen because filename is standarized concatenation of above fields
     filename = Column(Text)
 

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -338,6 +338,8 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
             "tone": "serious-but-not-really",
             "timestamp": 1577077883,
             "username": "guest",
+            "script": "??????????",  # FIXME: what is script?
+            "emphasis": "iss",  # like saying Nimbiss instead of Nimbus
             "filename": "ww_q_serious-but-not-really_here_m_doe_jj_1577077883_guest.wav"  # noqa because too hard.
         }
 
@@ -383,6 +385,7 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         metadata.first_name = formatted_data['firstName']
         metadata.last_name = formatted_data['lastName']
         metadata.gender = formatted_data['gender']
+        metadata.emphasis = formatted_data['emphasis']
 
         if (formatted_data['noiseLevel'] == 'q' or
                 formatted_data['noiseLevel'] == 'quiet'):
@@ -717,7 +720,9 @@ if __name__ == "__main__":
         "tone": "serious-but-not-really",
         "timestamp": 1577077883,
         "username": "guest",
-        "filename": "filename"
+        "filename": "filename",
+        "script": "??????????",  # FIXME: what is script?
+        "emphasis": "iss"  # like saying Nimbiss instead of Nimbus
     }
 
     db.save_audio_sample_meta_data(metadata)

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -350,7 +350,7 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         """
         keys_i_care_about = {
             'isWakeWord', 'firstName', 'lastName', 'gender', 'noiseLevel',
-            'location', 'tone', 'timestamp', 'username', 'filename'
+            'location', 'tone', 'timestamp', 'username', 'filename', 'emphasis'
         }
 
         print(formatted_data)
@@ -360,18 +360,10 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
             msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
             raise BadDictionaryKeyError(msg)
 
-        # assert that the formatted_data does not have extra keys
-        for k in formatted_data:
-            if k not in keys_i_care_about:
-                msg = "expected: {} but got: {}"
-                msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
-                raise BadDictionaryKeyError(msg)
-
         # assert that the keys_i_care_about are in formatted_data
         for k in keys_i_care_about:
             if k not in formatted_data:
-                msg = "expected: {} but got: {}"
-                msg = msg.format(keys_i_care_about, set(formatted_data.keys()))
+                msg = f"Field '{k}' is missing. Please include this value in the audio payload"
                 raise BadDictionaryKeyError(msg)
 
         # create an AudioSampleMetaData object with the given metadata
@@ -411,7 +403,7 @@ class NimbusMySQLAlchemy():  # NimbusMySQLAlchemy(NimbusDatabase):
         metadata.tone = formatted_data['tone']
         metadata.timestamp = formatted_data['timestamp']
         metadata.username = formatted_data['username']
-
+        metadata.script = formatted_data['script']
         metadata.filename = formatted_data['filename']
 
         # insert this new metadata object into the AudioSampleMetaData table

--- a/modules/validators.py
+++ b/modules/validators.py
@@ -64,6 +64,10 @@ class WakeWordValidator(Validator):
                 lambda timestamp: str.isdigit(timestamp),
             'username':
                 lambda username: type(username) == str,
+            'script':
+                lambda script: type(script) == str,
+            'emphasis':
+                lambda script: type(script) == str,
         }
 
     def validate(self, data):


### PR DESCRIPTION
I added an *emphasis* and *script* field to the sql call of the REST API. I also took out a validation check in `save_audio_sample_meta_data()` that would reject data with too much information. Since we would only take a subset of `formatted_data`, then we should only reject the data if there is too little information. 