### PR TITLE
added QA object

### DIFF
--- a/QA.py
+++ b/QA.py
@@ -1,0 +1,53 @@
+from typing import Callable, Dict, Any
+
+Extracted_Vars = Dict[str, Any]
+DB_Data = Dict[str, Any]
+DB_Query = Callable[[Extracted_Vars], DB_Data]
+Answer_Formatter = Callable[[Extracted_Vars, DB_Data], str]
+
+
+class QA:
+    """
+    A class for wrapping functions used to answer a question.
+    """
+
+    def __init__(self, q_format, db, db_query, format_function):
+        """
+        Args:
+            q_format (str): Question format string
+            db (NimbusDatabase): Object used to access remote database
+            db_query (DB_Query): Function used to get data from database. Takes
+                a dict of extracted variables and returns a dict of variables
+                from the database.
+            format_function (Answer_Formatter): Function used to format answer
+                string. Takes two dicts--one of extracted variables and one of
+                data retrieved from the database--and returns a str.
+        """
+        self.q_format = q_format
+        self.db = db
+        self.db_query = db_query
+        self.format_function = format_function
+
+    def _get_data_from_db(self, extracted_vars):
+        return self.db_query(extracted_vars)
+
+    def _format_answer(self, extracted_vars, db_data):
+        return self.format_function(extracted_vars, db_data)
+
+    def answer(self, extracted_vars):
+        db_data = self._get_data_from_db(extracted_vars)
+        return self._format_answer(extracted_vars, db_data)
+
+    def __hash__(self):
+        return hash(self.q_format)
+
+
+def create_qa_mapping(qa_list):
+    """
+    Creates a dictionary whose values are QA objects and keys are the question
+    formats of those QA objects.
+
+    Args:
+        qa_list (list(QA))
+    """
+    return {qa.q_format: qa for qa in qa_list}


### PR DESCRIPTION
## What's New?
Added a QA object mapping questions to answer behavior.

## Fixes #63

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Simple tests with dummy db_query and format_answer questions. Using the QA object to access the database has not been tested.

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
