### PR TITLE
Add endpoints for scraped data

### DIFF
--- a/Entity/Locations.py
+++ b/Entity/Locations.py
@@ -4,9 +4,9 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 class Locations(Base):
-    __tablename__ = 'Location'
+    __tablename__ = 'Locations'
     location_id = Column(Integer, primary_key = True)
-    building_number = Column(Integer)
+    building_number = Column(String(5))
     name = Column(String(100))
     longitude = Column(String(255))
     latitude = Column(String(255))

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -526,7 +526,15 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
              True if all is good, else False
         """
 
-        club_data = Clubs()
+        expected_keys = {'club_name', 'types', 'desc', 'contact_email',
+                         'contact_email_2', 'contact_person', 'contact_phone',
+                         'box', 'advisor', 'affiliation'}
+        self.validate_input_keys(formatted_data, expected_keys)
+
+        club_data = self.session.query(Clubs).filter_by(club_name=formatted_data['club_name']).first()
+        if not club_data:
+            club_data = Clubs()
+
         club_data.club_name = formatted_data['club_name']
         club_data.types = formatted_data['types']
         club_data.desc = formatted_data['desc']
@@ -666,12 +674,7 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         course = self.session.query(Courses).filter_by(dept=course_data['dept'],
                                                        courseNum=course_data['courseNum']).first()
         if not course:
-            print("Adding new course: {} {}".format(course_data['dept'],
-                                                    course_data['courseNum']))
             course = Courses()
-        else:
-            print("Updating course: {} {}".format(course_data['dept'],
-                                                  course_data['courseNum']))
 
         course.dept = course_data['dept']
         course.courseNum = course_data['courseNum']
@@ -706,7 +709,13 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         Returns:
             True if all good, else False
         """
-        location = Locations()
+        expected_keys = {'building_number', 'name', 'longitude', 'latitude'}
+        self.validate_input_keys(location_data, expected_keys)
+
+        location = self.session.query(Locations).filter_by(name=location_data['name']).first()
+        if not location:
+            location = Locations()
+
         location.building_number = location_data["building_number"]
         location.name = location_data["name"]
         location.longitude = location_data["longitude"]
@@ -739,8 +748,14 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
          Returns:
              True if all is good, else False
         """
+        expected_keys = {'date', 'day', 'month', 'year', 'raw_events_text'}
+        self.validate_input_keys(calendar_data, expected_keys)
 
-        calendar = Calendars()
+        calendar = self.session.query(Calendars).filter_by(date=calendar_data['date'],
+                                                           raw_events_text=calendar_data['raw_events_text']).first()
+        if not calendar:
+            calendar = Calendars()
+
         calendar.date = calendar_data["date"]
         calendar.day = calendar_data["day"]
         calendar.month = calendar_data["month"]

--- a/flask_api.py
+++ b/flask_api.py
@@ -138,6 +138,81 @@ def save_courses():
     return "SUCCESS"
 
 
+@app.route('/new_data/clubs', methods=['POST'])
+def save_clubs():
+    """
+    Persists list of clubs
+    """
+    data = json.loads(request.get_json())
+    db = NimbusMySQLAlchemy(config_file=CONFIG_FILE_PATH)
+    for club in data['clubs']:
+        try:
+            db.save_club(club)
+        except BadDictionaryKeyError as e:
+            return str(e), BAD_REQUEST
+        except BadDictionaryValueError as e:
+            return str(e), BAD_REQUEST
+        except NimbusDatabaseError as e:
+            return str(e), BAD_REQUEST
+        except Exception as e:
+            # TODO: consider security tradeoff of displaying internal server errors
+            #       versus development time (being able to see errors quickly)
+            # HINT: security always wins
+            raise e
+
+    return "SUCCESS"
+
+
+@app.route('/new_data/locations', methods=['POST'])
+def save_locations():
+    """
+    Persists list of locations
+    """
+    data = json.loads(request.get_json())
+    db = NimbusMySQLAlchemy(config_file=CONFIG_FILE_PATH)
+    for location in data['locations']:
+        try:
+            db.save_location(location)
+        except BadDictionaryKeyError as e:
+            return str(e), BAD_REQUEST
+        except BadDictionaryValueError as e:
+            return str(e), BAD_REQUEST
+        except NimbusDatabaseError as e:
+            return str(e), BAD_REQUEST
+        except Exception as e:
+            # TODO: consider security tradeoff of displaying internal server errors
+            #       versus development time (being able to see errors quickly)
+            # HINT: security always wins
+            raise e
+
+    return "SUCCESS"
+
+
+@app.route('/new_data/calendars', methods=['POST'])
+def save_calendars():
+    """
+    Persists list of calendars
+    """
+    data = json.loads(request.get_json())
+    db = NimbusMySQLAlchemy(config_file=CONFIG_FILE_PATH)
+    for calendar in data['calendars']:
+        try:
+            db.save_calendar(calendar)
+        except BadDictionaryKeyError as e:
+            return str(e), BAD_REQUEST
+        except BadDictionaryValueError as e:
+            return str(e), BAD_REQUEST
+        except NimbusDatabaseError as e:
+            return str(e), BAD_REQUEST
+        except Exception as e:
+            # TODO: consider security tradeoff of displaying internal server errors
+            #       versus development time (being able to see errors quickly)
+            # HINT: security always wins
+            raise e
+
+    return "SUCCESS"
+
+
 def create_filename(form):
     """
     Creates a string filename that adheres to the Nimbus foramtting standard.


### PR DESCRIPTION
## What's New?
* Update `Clubs`, `Locations`, and `Calendars` to update if an entry already exists
* Create APIs to send `Clubs`, `Locations`, and `Calendars` data to from scraper

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
1. Ensure your local connection to `MySQL`
2. Clone `https://github.com/calpoly-csai/csai-scraping`
3. Run `flask_api.py` in `api` package
4. Run `sustainer.py` in `csai-scraping` package
5. View `Clubs`, `Locations`, and `Calendars` tables in MySQL

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [x] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
