### PR TITLE
This fixes the segfaults on Ubuntu. 

### DIFF
--- a/nimbus.py
+++ b/nimbus.py
@@ -1,3 +1,10 @@
+# This import fixes a segfault on Ubuntu 18.04.1 LTS.  It doesn't seem to do anything,
+# and doesn't seem to be used by anything, but if its removed, the program segfaults.
+# See issue #90 on github. This segfault does not occur on Mac or Windows.
+# Feel free to debug this if you would like.  Current dev hours counter on this issue:
+# 30 hours
+# Update the counter above if you work on this issue.
+#
 from werkzeug.exceptions import BadRequestKeyError
 from QA import create_qa_mapping, generate_fact_QA
 from nimbus_nlp.NIMBUS_NLP import NIMBUS_NLP

--- a/nimbus.py
+++ b/nimbus.py
@@ -1,3 +1,4 @@
+from werkzeug.exceptions import BadRequestKeyError
 from QA import create_qa_mapping, generate_fact_QA
 from nimbus_nlp.NIMBUS_NLP import NIMBUS_NLP
 


### PR DESCRIPTION
 The import does not seem to be actually used by anything, so we need to investigate
why this fixes things. This causes a linting error for unused import.  We should probably try and figure out what the true root cause is.

## What's New?
This adds a new import to nimbus.py which fixes the segfault issue on ubuntu.

## Fixes #90 on Ubuntu

## Type of change (pick-one)
- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Ran nimbus.py on Ubuntu 18.04.1 LTS
```
$ cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```
```
$ uname -r
4.15.0-22-generic
```


## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [x] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
