### PR TITLE
ensures people dont reference #9 on accident

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context. 
 List any dependencies that are required for this change.
 
-## Fixes #<<ISSUE_NUMBER>> ... (e.g. #9)
+## Fixes #<<ISSUE_NUMBER>> ... `(e.g. #9)`
 
 ## Type of change (pick-one)
 - [ ] Bug fix (_non-breaking change which fixes an issue_)


### PR DESCRIPTION
## What's New?
Avoids human error. Too many people reference #9 due to not modifying the pull request template.

## Fixes #9 (not _really_ but like **_yeah kinda_**)

## Type of change (pick-one)
- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
N/A simply a documentation bug fix.

## Checklist (check-all-before-merge)
N/A simply a documentation bug fix.