### PR TITLE
improve deploy scripts and allow for profiling memory performance

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ pytest = "==5.3.4"
 pyre-check = "==0.0.41"
 ## like the Unix `make` but better
 invoke = "==1.4.1"
-
+memory-profiler = "*"
 
 [packages]
 # REST API
@@ -61,6 +61,8 @@ six = "==1.11.0"
 idna = "==2.6"
 ## because google-auth 1.11.2 wants setuptools>=40.3.0
 setuptools = ">=40.3.0"
+colorama = "*"
+termcolor = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fb30d39142d3cc83d8909d9f4f4648a60ac33d4ec3a5a94d8dac7b90ef727a24"
+            "sha256": "41204f6690fe07c38c1bae8b4faf75cd22d21404e06ea4e5ff8d7876baae06a3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -71,6 +71,14 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "index": "pypi",
+            "version": "==0.4.3"
         },
         "cymem": {
             "hashes": [
@@ -651,6 +659,13 @@
             ],
             "version": "==1.0.1"
         },
+        "termcolor": {
+            "hashes": [
+                "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "thinc": {
             "hashes": [
                 "sha256:1dbaec0628040a1f8d66147fadbf7775ad6dfe4c681424b2e20479c1e54dc3c1",
@@ -825,6 +840,13 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "memory-profiler": {
+            "hashes": [
+                "sha256:23b196f91ea9ac9996e30bfab1e82fecc30a4a1d24870e81d1e81625f786a2c3"
+            ],
+            "index": "pypi",
+            "version": "==0.57.0"
         },
         "more-itertools": {
             "hashes": [

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-python3 setup_special_files_from_env.py
-./download_nlp_stuff.sh
-python3 download_nltk_stuff.py
-gunicorn flask_api:app --config=gunicorn_config.py
+python3 setup_special_files_from_env.py && \
+    ./download_nlp_stuff.sh && \
+    python3 download_nltk_stuff.py && \
+    gunicorn flask_api:app --config=gunicorn_config.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ catalogue==1.0.0
 certifi==2019.11.28
 chardet==3.0.4
 Click==7.0
+colorama==0.4.3
 cymem==2.0.3
 Flask==1.1.1
 Flask-Cors==3.0.8
@@ -48,6 +49,7 @@ six==1.11.0
 spacy==2.2.3
 SQLAlchemy==1.3.13
 srsly==1.0.1
+termcolor==1.1.0
 thinc==7.3.1
 tqdm==4.43.0
 uritemplate==3.0.1

--- a/setup_special_files_from_env.py
+++ b/setup_special_files_from_env.py
@@ -2,6 +2,12 @@
 from os import environ
 import json
 from utilities import yaml_utils  # noqa
+from colorama import init
+from termcolor import colored
+
+# initialize colorama
+init()
+
 
 # NimbusDatabase stuff
 SAMPLE_CONFIG_FILE = "config.json_SAMPLE"
@@ -22,7 +28,9 @@ GOOGLE_DRIVE_CREDENTIALS_KEY = "GOOGLE_DRIVE_CREDENTIALS"
 GOOGLE_CLOUD_NLP_CREDENTIALS_FILE = "auth.json"
 GOOGLE_CLOUD_NLP_CREDENTIALS_KEY = "GOOGLE_CLOUD_NLP_CREDENTIALS"
 
-BAD_CONFIG_MSG = "uh oh, config vars not set, check heroku settings"
+BAD_CONFIG_MSG = "uh oh, config vars not set,\n\tmake sure to\n\t" + colored(
+    "source .export_env_vars", "white", "on_cyan", attrs=["bold"]
+)
 assert environ.get("DATABASE_HOSTNAME", None) is not None, BAD_CONFIG_MSG
 assert environ.get("DATABASE_PASSWORD", None) is not None, BAD_CONFIG_MSG
 assert environ.get("DATABASE_USERNAME", None) is not None, BAD_CONFIG_MSG
@@ -36,7 +44,12 @@ assert environ.get("GOOGLE_CLOUD_NLP_CREDENTIALS", None) is not None, BAD_CONFIG
 assert environ.get("GOOGLE_CLOUD_NLP_MODEL_NAME", None) is not None, BAD_CONFIG_MSG  # noqa
 # fmt: on
 
-BAD_CONFIG_MSG_2 = "uh oh, config var is empty string, check docker"
+BAD_CONFIG_MSG_2 = "uh oh, config var , check docker"
+
+BAD_CONFIG_MSG_2 = "uh oh, config var is empty string,\n\tcheck docker OR make sure to\n\t" + colored(
+    "source .export_env_vars", "white", "on_cyan", attrs=["bold"]
+)
+
 assert environ.get("DATABASE_HOSTNAME", None) != "", BAD_CONFIG_MSG_2
 assert environ.get("DATABASE_PASSWORD", None) != "", BAD_CONFIG_MSG_2
 assert environ.get("DATABASE_USERNAME", None) != "", BAD_CONFIG_MSG_2


### PR DESCRIPTION
# What's New?
* adds [memory-profiler](https://github.com/pythonprofilers/memory_profiler) as a `dev-dependency` within the Pipfile
* uses [`colorama`](https://pypi.org/project/colorama/) and [`termcolor`](https://pypi.org/project/termcolor/) to make the `./deploy.sh` script more helpful @Jason-Ku may find these packages to be interesting/useful
 
## Related to #103 
## Progress toward #101 

# Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [x] This change requires a documentation update
  * **probably a good idea to document how to use `memory-profiler` in the README**
  * **probably a good idea to document how the deploy scripts work in the README**

# How Has This Been Tested?
### Screenshots
#### notice the color when user forgets to set environment variables
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/11131250/75724519-6acd2a80-5c93-11ea-9209-dac3a42e6d90.png">

#### also colorful when environment variables are empty string on accident
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/11131250/75724571-89cbbc80-5c93-11ea-96b8-11e1b3c9637e.png">


# Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
