### PR TITLE
Remove last raw_data_dict reference

### DIFF
--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -704,7 +704,7 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         else:
             msg = "unexpected values for isWakeWord\n"
             msg += "expected 'ww' or True or 'nww' or False but got '{}'"
-            msg = msg.format(raw_data_dict["isWakeWord"])
+            msg = msg.format(data_dict["isWakeWord"])
             raise BadDictionaryValueError(msg)
 
         if data_dict["noiseLevel"] in noise_level_by_label:


### PR DESCRIPTION
## What's New?
stray raw_data_dict reference replaced with data_dict. Should prevent the api from crashing if trying to save an AudioSampleMetaData Entity. 

## Type of change (pick-one)
- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
sanity tested

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
