### PR TITLE
Get code coverage up

### DIFF
--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -375,14 +375,14 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
             msg = msg.format(expected_keys, set(input_data.keys()))
             raise BadDictionaryKeyError(msg)
 
-        # assert that the formatted_data does not have extra keys
+        # assert that the input_data does not have extra keys
         for k in input_data:
             if k not in expected_keys:
                 msg = "expected: {} but got: {}"
                 msg = msg.format(expected_keys, set(input_data.keys()))
                 raise BadDictionaryKeyError(msg)
 
-        # assert that the keys_i_care_about are in formatted_data
+        # assert that the keys_i_care_about are in input_data
         for k in expected_keys:
             if k not in input_data:
                 msg = "expected: {} but got: {}"
@@ -415,7 +415,6 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         print("initialized database session")
 
     def get_all_qa_pairs(self):
-
         qa_entity = QuestionAnswerPair
 
         query_session = self.session.query(qa_entity.question_format, qa_entity.answer_format)
@@ -710,69 +709,5 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
 
         return data_dict
 
-    def _execute(self, query: str):
-        return self.engine.execute(query)
-
     def __del__(self):
         print("NimbusMySQLAlchemy closed")
-
-
-if __name__ == "__main__":
-    db = NimbusMySQLAlchemy()
-    db._create_all_tables()
-
-    data = {
-        "isWakeWord": True,
-        "firstName": "jj",
-        "lastName": "doe",
-        "gender": "f",
-        "noiseLevel": "q",
-        "location": "here",
-        "tone": "serious-but-not-really",
-        "timestamp": 1577077883,
-        "username": "guest",
-        "filename": "ww_q_serious-but-not-really_here_m_doe_jj_1577077883_guest.wav",  # noqa because too hard.
-    }
-
-    db.insert_entity(AudioSampleMetaData, data)
-
-    data = {
-        "building_number": 1,
-        "name": "Administration",
-        "longitude": -120.658561,
-        "latitude": 35.300960,
-    }
-
-    db.update_entity(Locations, data, ["building_number"])
-
-    data = {
-        "club_name": "Cal Poly Computer Science and Artificial Intelligence",
-        "types": "Academic, Special Interest",
-        "desc": "The Computer Science and Artificial Intelligence club provides...",
-        "contact_email": "maikens@calpoly.edu",
-        "contact_email_2": "fkurfess@calpoly.edu",
-        "contact_person": "Miles Aikens",
-        "contact_phone": "7349723564",
-        "box": "89",
-        "advisor": "Franz Kurfess",
-        "affiliation": "None",
-    }
-
-    db.insert_entity(Clubs, data)
-
-    data = {
-        "section_name": "CSC 480_06",
-        "instructor": "Kauffman, Daniel Alexander",
-        "alias": "dkauffma",
-        "title": "Instructor AY",
-        "phone": "+1.805.756.2824",
-        "office": "014-0254A",
-        "type": SectionType.lab,
-        "days": set({"M", "W", "F"}),
-        "start": "10:10 AM",
-        "end": "11:00 AM",
-        "location": "014-0257",
-        "department": "CENG-Computer Science & Software Engineering",
-    }
-
-    db.insert_entity(Sections, data)

--- a/tests/MockEntity.py
+++ b/tests/MockEntity.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 
-class TestEntity(Base):
+class MockEntity(Base):
     __tablename__ = "Test"
     entity_id = Column(Integer, primary_key=True)
     value_one = Column(String(64))
@@ -12,6 +12,6 @@ class TestEntity(Base):
     value_three = Column(String(64))
 
     def __repr__(self):
-        return "<TestEntity (value_one={}, value_two={}, value_three={})>".format(
+        return "<MockEntity (value_one={}, value_two={}, value_three={})>".format(
             self.value_one, self.value_two, self.value_three
         )

--- a/tests/test_database_wrapper.py
+++ b/tests/test_database_wrapper.py
@@ -1,63 +1,263 @@
+import json
+import os
+import pytest
+
+from database_wrapper import (NimbusMySQLAlchemy, BadDictionaryKeyError, BadDictionaryValueError,
+                              NimbusDatabaseError, UnsupportedDatabaseError, BadConfigFileError)
 from mock import patch, Mock
-from database_wrapper import *
-from .TestEntity import TestEntity
+from .MockEntity import MockEntity
 
 
-data_dict = {
+ENTITY_TYPES = ["AudioSampleMetaData", "Calendars", "Courses", "Locations",
+                "QuestionAnswerPair", "Professors", "Clubs", "Sections"]
+
+MOCK_ENTITY_DATA_DICT = {
     "value_one": "test1",
     "value_two": "test2",
     "value_three": "test3"
 }
 
+TEST_AUDIO_SAMPLE_META_DATA_DATA_DICT = {
+    "isWakeWord": True,
+    "firstName": "jj",
+    "lastName": "doe",
+    "gender": "f",
+    "noiseLevel": "q",
+    "location": "here",
+    "tone": "serious-but-not-really",
+    "timestamp": 1577077883,
+    "username": "guest",
+    "filename": "ww_q_serious-fake_m_doe_jj_1577077883_guest.wav"
+}
 
-@patch.object(NimbusMySQLAlchemy, "validate_and_format_entity_data")
+TEST_CONFIG_FILENAME = "testConfig.json"
+TEST_CONFIG_DICT = {
+    "mysql": {
+        "host": "testHost",
+        "port": "testPort",
+        "user": "testUser",
+        "password": "testPassword",
+        "database": "testDatabase"
+    },
+}
+
+RDBMS = "mysql"
+PIP_PACKAGE = "mysqlconnector"
+SQLALCHEMY_DATABASE_URI = "{}+{}://{}:{}@{}:{}/{}".format(
+    RDBMS,
+    PIP_PACKAGE,
+    TEST_CONFIG_DICT["mysql"]["user"],
+    TEST_CONFIG_DICT["mysql"]["password"],
+    TEST_CONFIG_DICT["mysql"]["host"],
+    TEST_CONFIG_DICT["mysql"]["port"],
+    TEST_CONFIG_DICT["mysql"]["database"]
+)
+
+
 @patch.object(NimbusMySQLAlchemy, "_create_engine")
-@patch.object(NimbusMySQLAlchemy, "_create_database_session")
-def test_insert_entity(mock_create_session, mock_create_engine ,mock_validate):
+def test_validate_input_keys(mock_create_engine):
+    test_db = NimbusMySQLAlchemy()
+    test_db.validate_input_keys(MOCK_ENTITY_DATA_DICT, MOCK_ENTITY_DATA_DICT.keys())
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_validate_input_keys_no_input(mock_create_engine):
+    test_db = NimbusMySQLAlchemy
+    with pytest.raises(BadDictionaryKeyError):
+        test_db.validate_input_keys({}, [])
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_validate_input_keys_extra_keys(mock_create_engine):
+    test_db = NimbusMySQLAlchemy
+    extra_key_dict = dict(MOCK_ENTITY_DATA_DICT)
+    extra_key_dict["value_extra"] = "test4"
+    with pytest.raises(BadDictionaryKeyError):
+        test_db.validate_input_keys(extra_key_dict, MOCK_ENTITY_DATA_DICT.keys())
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_validate_input_keys_missing_keys(mock_create_engine):
+    test_db = NimbusMySQLAlchemy
+    missing_key_dict = {"value_one": "test1"}
+    with pytest.raises(BadDictionaryKeyError):
+        test_db.validate_input_keys(missing_key_dict, MOCK_ENTITY_DATA_DICT.keys())
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_create_all_tables(mock_create_engine):
+    test_db = NimbusMySQLAlchemy()
+
+    for entity_type in ENTITY_TYPES:
+        mock_entity = Mock()
+        mock_entity.__tablename__ = entity_type
+        mock_entity.__table__ = Mock()
+        mock_entity.__table__.create.return_value = None
+        setattr(test_db, entity_type, mock_entity)
+
+    test_db._create_all_tables()
+
+    # Verify that each Entity had .create() called on it once.
+    for entity_type in ENTITY_TYPES:
+        getattr(test_db, entity_type).__table__.create.assert_called_once()
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_create_all_tables_already_exists(mock_create_engine):
+    mock_inspector = Mock()
+    mock_inspector.get_table_names.return_value = ENTITY_TYPES
+
+    test_db = NimbusMySQLAlchemy()
+    test_db.inspector = mock_inspector
+
+    for entity_type in ENTITY_TYPES:
+        mock_entity = Mock()
+        mock_entity.__tablename__ = entity_type
+        mock_entity.__table__ = Mock()
+        setattr(test_db, entity_type, mock_entity)
+
+    test_db._create_all_tables()
+
+    # Verify that each Entity did not have .create() called on it
+    for entity_type in ENTITY_TYPES:
+        assert not getattr(test_db, entity_type).__table__.create.called
+
+
+@patch.object(NimbusMySQLAlchemy, "validate_and_format_entity_data", return_value=MOCK_ENTITY_DATA_DICT)
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_insert_entity(mock_create_engine, mock_validate):
     # Setup mocks and test_db instance
-    mock_validate.return_value = data_dict
     test_db = NimbusMySQLAlchemy()
     test_db.session = Mock()
 
     # Insert entity and assert that add/commit were called
-    test_db.insert_entity(TestEntity, data_dict)
+    test_db.insert_entity(MockEntity, MOCK_ENTITY_DATA_DICT)
     test_db.session.add.assert_called_once()
     test_db.session.commit.assert_called_once()
 
     # Assert that the entity inserted was populated with the right fields
     entity = test_db.session.add.call_args.args[0]
+    for field in list(MOCK_ENTITY_DATA_DICT.keys()):
+        assert getattr(entity, field) is MOCK_ENTITY_DATA_DICT[field]
 
-    for field in list(data_dict.keys()):
-        assert getattr(entity, field) is data_dict[field]
 
-
-@patch.object(NimbusMySQLAlchemy, "validate_and_format_entity_data")
+@patch.object(NimbusMySQLAlchemy, "validate_and_format_entity_data", return_value=MOCK_ENTITY_DATA_DICT)
 @patch.object(NimbusMySQLAlchemy, "_create_engine")
-@patch.object(NimbusMySQLAlchemy, "_create_database_session")
-def test_update_entity(mock_create_session, mock_create_engine, mock_validate):
+def test_update_entity_no_match(mock_create_engine, mock_validate):
     # Setup mocks and test_db instance
-    mock_validate.return_value = data_dict
+    mock_session = Mock()
+    mock_query = Mock()
+
+    mock_session.query.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = None
+
     test_db = NimbusMySQLAlchemy()
-    test_db.session = Mock()
+    test_db.session = mock_session
 
     # Insert entity and assert that add/commit were called
-    test_db.update_entity(TestEntity, data_dict, ["value_one"])
+    test_db.update_entity(MockEntity, MOCK_ENTITY_DATA_DICT, ["value_one"])
     test_db.session.add.assert_called_once()
     test_db.session.commit.assert_called_once()
 
     # Assert that the entity inserted was populated with the right fields
     entity = test_db.session.add.call_args.args[0]
+    for field in list(MOCK_ENTITY_DATA_DICT.keys()):
+        assert getattr(entity, field) is MOCK_ENTITY_DATA_DICT[field]
 
-    for field in list(data_dict.keys()):
-        assert getattr(entity, field) is data_dict[field]
+
+@patch.object(NimbusMySQLAlchemy, "validate_and_format_entity_data", return_value=MOCK_ENTITY_DATA_DICT)
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_update_entity_match(mock_create_engine, mock_validate):
+    # Setup mocks and test_db instance
+    mock_session = Mock()
+    mock_query = Mock()
+
+    mock_session.query.return_value = mock_query
+    mock_query.filter.return_value = mock_query
+    mock_query.first.return_value = MockEntity
+
+    test_db = NimbusMySQLAlchemy()
+    test_db.session = mock_session
+
+    # Insert entity and assert that add/commit were called
+    test_db.update_entity(MockEntity, MOCK_ENTITY_DATA_DICT, ["value_one"])
+    test_db.session.add.assert_called_once()
+    test_db.session.commit.assert_called_once()
+
+    # Assert that the entity inserted was populated with the right fields
+    entity = test_db.session.add.call_args.args[0]
+    for field in list(MOCK_ENTITY_DATA_DICT.keys()):
+        assert getattr(entity, field) is MOCK_ENTITY_DATA_DICT[field]
 
 
 @patch.object(NimbusMySQLAlchemy, "_create_engine")
-@patch.object(NimbusMySQLAlchemy, "_create_database_session")
-def test_update_entity_no_filter_fields_error(mock_create_engine, mock_create_session):
+def test_update_entity_no_filter_fields_error(mock_create_engine):
     test_db = NimbusMySQLAlchemy()
-    try:
-        test_db.update_entity(TestEntity, data_dict, [])
-    except RuntimeError as e:
-        if "requires filter_fields list" not in str(e):
-            raise RuntimeError("Error not raised")
+    with pytest.raises(RuntimeError, match="filter"):
+        test_db.update_entity(MockEntity, MOCK_ENTITY_DATA_DICT, [])
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_invalid_entity_type(mock_create_engine):
+    test_db = NimbusMySQLAlchemy()
+    with pytest.raises(KeyError):
+        test_db.insert_entity(MockEntity, MOCK_ENTITY_DATA_DICT)
+    with pytest.raises(KeyError):
+        test_db.update_entity(MockEntity, MOCK_ENTITY_DATA_DICT, ["test"])
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_format_audio_sample_meta_data_dict(mock_create_engine):
+    test_db = NimbusMySQLAlchemy()
+    test_db.format_audio_sample_meta_data_dict(dict(TEST_AUDIO_SAMPLE_META_DATA_DATA_DICT))
+
+
+@patch.object(NimbusMySQLAlchemy, "_create_engine")
+def test_format_audio_sample_meta_data_dict_bad_input(mock_create_engine):
+    test_db = NimbusMySQLAlchemy()
+    invalid_is_wake_word = dict(TEST_AUDIO_SAMPLE_META_DATA_DATA_DICT)
+    invalid_is_wake_word["isWakeWord"] = "test"
+    invalid_noise_level = dict(TEST_AUDIO_SAMPLE_META_DATA_DATA_DICT)
+    invalid_noise_level["noiseLevel"] = "test"
+
+    with pytest.raises(BadDictionaryValueError):
+        test_db.format_audio_sample_meta_data_dict(invalid_is_wake_word)
+    with pytest.raises(BadDictionaryValueError):
+        test_db.format_audio_sample_meta_data_dict(invalid_noise_level)
+
+
+@patch("database_wrapper.create_engine")
+def test_create_engine(mock_create_engine):
+    mock_engine = Mock()
+    mock_create_engine.return_value = mock_engine
+
+    with open("testConfig.json", "w+") as test_config:
+        json.dump(TEST_CONFIG_DICT, test_config)
+
+    test_db = NimbusMySQLAlchemy(TEST_CONFIG_FILENAME)
+    mock_create_engine.assert_called_once_with(SQLALCHEMY_DATABASE_URI)
+    assert test_db.engine is mock_engine
+
+    os.remove(TEST_CONFIG_FILENAME)
+
+
+@patch("database_wrapper.create_engine", return_value=None)
+def test_create_engine_bad_config(mock_create_engine):
+    with open(TEST_CONFIG_FILENAME, "w+") as test_config:
+        json.dump(TEST_CONFIG_DICT, test_config)
+
+    with pytest.raises(BadConfigFileError, match="failed to connect"):
+        test_db = NimbusMySQLAlchemy(TEST_CONFIG_FILENAME)
+
+    os.remove(TEST_CONFIG_FILENAME)
+
+
+def test_create_engine_missing_field():
+    with open(TEST_CONFIG_FILENAME, "w+") as test_config:
+        json.dump({}, test_config)
+
+    with pytest.raises(BadConfigFileError, match="missing mysql field"):
+        test_db = NimbusMySQLAlchemy(TEST_CONFIG_FILENAME)
+
+    os.remove(TEST_CONFIG_FILENAME)


### PR DESCRIPTION
## What's New?
* New tests for code coverage, tests almost everything that is testable without some funky work, I think. Most importantly, none of these tests require a db connection
* Removed some dead code (`_execute` function in `NimbusMySQLAlchemy`), let me know if this going to be used, we can add it back.
* Removed all the junk from the database_wrapper.py main method, shouldn't need it anymore now that we have tests, I hope. If theres a case for keeping it there, we can add it back.

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/13087024/77379697-942f2280-6d36-11ea-9697-9ac7c655eea3.png)



## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [x] I added my tests to the `/tests` directory

- [x] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
