### PR TITLE
Add initial tests for flask_api.py

### DIFF
--- a/QA.py
+++ b/QA.py
@@ -23,11 +23,6 @@ tag_lookup = {
     'SECTION': Sections
 }
 
-# TODO: Initialize this somewhere else. Currently here because of _get_property()
-# Move into the Nimbus class below if possible.
-db = NimbusMySQLAlchemy()
-
-
 class QA:
     """
     A class for wrapping functions used to answer a question.
@@ -161,6 +156,7 @@ def _get_property(prop, extracted_info):
     ent_string = extracted_info["normalized entity"]
     ent = tag_lookup[extracted_info['tag']]
     try:
+        db = NimbusMySQLAlchemy()
         value = db.get_property_from_entity(prop=prop, entity=ent, identifier=ent_string)
     except IndexError:
         return None

--- a/flask_api.py
+++ b/flask_api.py
@@ -44,9 +44,6 @@ CONFIG_FILE_PATH = "config.json"
 app = Flask(__name__)
 CORS(app)
 
-# TODO: Initialize this somewhere else.
-nimbus = Nimbus()
-
 
 @app.route("/", methods=["GET", "POST"])
 def hello():
@@ -82,6 +79,7 @@ def handle_question():
     if "question" not in request_body:
         return "request body should include the question", BAD_REQUEST
 
+    nimbus = Nimbus()
     response = {"answer": nimbus.answer_question(question)}
 
     if "session" in request_body:

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -1,0 +1,61 @@
+import json
+import pytest
+
+import flask_api
+from database_wrapper import (NimbusMySQLAlchemy, BadDictionaryKeyError, BadDictionaryValueError,
+                              NimbusDatabaseError, UnsupportedDatabaseError, BadConfigFileError)
+from mock import patch, Mock
+from .MockEntity import MockEntity
+
+
+BAD_REQUEST = 400
+SUCCESS = 200
+SERVER_ERROR = 500
+TOKEN = "test_token"
+
+@pytest.fixture
+def client():
+    flask_api.app.config['TESTING'] = True
+
+    with flask_api.app.test_client() as client:
+        yield client
+
+
+def test_hello(client):
+    resp = client.get('/')
+    assert resp.json == {"name": "hello {}".format(flask_api.app)}
+
+    test_data_dict = {"hello": "world"}
+    resp = client.post('/', json=test_data_dict)
+    assert resp.json == {"you sent": test_data_dict}
+
+
+def test_ask_request_not_json(client):
+    resp = client.post('/ask', data="dummy data")
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == b'request must be JSON'
+
+
+def test_ask_no_question(client):
+    resp = client.post('/ask', json={})
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == b'request body should include the question'
+
+
+@patch("flask_api.generate_session_token", return_value=TOKEN)
+@patch("flask_api.Nimbus")
+def test_ask_question(mock_nimbus, mock_generate_session_token, client):
+    mock_nimbus_client = Mock()
+    mock_nimbus.return_value = mock_nimbus_client
+    mock_nimbus_client.answer_question.return_value = "test_answer"
+
+    # Verify that calling ask without a token will return a response with a new token
+    resp = client.post('/ask', json={"question": "test_question"})
+    assert resp.status_code == SUCCESS
+    assert resp.json == {"answer": "test_answer", "session": TOKEN}
+
+    # Verify that calling ask with a token will return a response with the same token
+    dummy_token = "dummy_token"
+    resp = client.post('/ask', json={"question": "test_question", "session": dummy_token})
+    assert resp.status_code == SUCCESS
+    assert resp.json == {"answer": "test_answer", "session": dummy_token}


### PR DESCRIPTION
## What's New?
This PR ought to come after https://github.com/calpoly-csai/api/pull/125, and is thus stacked ontop of it.

Adds some initial tests for flask_api.py. 

## How Has This Been Tested?
`python -m pytest` 
![image](https://user-images.githubusercontent.com/13087024/78517082-c4cc7e80-7770-11ea-81d8-8725c414f1d8.png)

Not quite sure how to fix the warnings, though.

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [x] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
