### PR TITLE
Flask app new wakeword data endpoint tests

### DIFF
--- a/flask_api.py
+++ b/flask_api.py
@@ -129,7 +129,7 @@ def save_a_recording():
     if issues:
         try:
             data = validator.fix(data, issues)
-        except FormatterValidatorError as err:
+        except WakeWordValidatorError as err:
             return str(err), BAD_REQUEST
     formatted_data = formatter.format(data)
     filename = create_filename(formatted_data)

--- a/tests/test_flask_api.py
+++ b/tests/test_flask_api.py
@@ -4,7 +4,9 @@ import pytest
 import flask_api
 from database_wrapper import (NimbusMySQLAlchemy, BadDictionaryKeyError, BadDictionaryValueError,
                               NimbusDatabaseError, UnsupportedDatabaseError, BadConfigFileError)
+from io import BytesIO
 from mock import patch, Mock
+from modules.validators import WakeWordValidatorError
 from .MockEntity import MockEntity
 
 
@@ -12,6 +14,7 @@ BAD_REQUEST = 400
 SUCCESS = 200
 SERVER_ERROR = 500
 TOKEN = "test_token"
+TEST_ERROR = "test error string"
 
 
 @pytest.fixture
@@ -31,45 +34,102 @@ def test_hello(client):
     assert resp.json == {"you sent": test_data_dict}
 
 
-@patch("flask_api.Nimbus")
-@patch("flask_api.NimbusMySQLAlchemy")
+@patch("flask_api.nimbus")
+@patch("flask_api.db")
 def test_ask_request_not_json(mock_db, mock_nimbus, client):
-    mock_db.return_value = None
-    mock_nimbus.return_value = None
-
     resp = client.post('/ask', data="dummy data")
     assert resp.status_code == BAD_REQUEST
     assert resp.data == b'request must be JSON'
 
 
-@patch("flask_api.Nimbus")
-@patch("flask_api.NimbusMySQLAlchemy")
+@patch("flask_api.nimbus")
+@patch("flask_api.db")
 def test_ask_no_question(mock_db, mock_nimbus, client):
-    mock_db.return_value = None
-    mock_nimbus.return_value = None
-
     resp = client.post('/ask', json={})
     assert resp.status_code == BAD_REQUEST
     assert resp.data == b'request body should include the question'
 
 
 @patch("flask_api.generate_session_token", return_value=TOKEN)
-@patch("flask_api.Nimbus")
-@patch("flask_api.NimbusMySQLAlchemy")
+@patch("flask_api.nimbus")
+@patch("flask_api.db")
 def test_ask_question(mock_db, mock_nimbus, mock_generate_session_token, client):
-    mock_db.return_value = None
-    mock_nimbus_client = Mock()
-    mock_nimbus_client.answer_question.return_value = "test_answer"
-    mock_nimbus.return_value = mock_nimbus_client
+    test_answer = "test_answer"
+    dummy_token = "dummy_token"
+
+    mock_nimbus.answer_question.return_value = test_answer
 
     # Verify that calling ask without a token will return a response with a new token
     resp = client.post('/ask', json={"question": "test_question"})
     assert resp.status_code == SUCCESS
-    assert resp.json == {"answer": "test_answer", "session": TOKEN}
+    assert resp.json == {"answer": test_answer, "session": TOKEN}
 
     # Verify that calling ask with a token will return a response with the same token
-    dummy_token = "dummy_token"
     resp = client.post('/ask', json={"question": "test_question", "session": dummy_token})
     assert resp.status_code == SUCCESS
-    assert resp.json == {"answer": "test_answer", "session": dummy_token}
-    
+    assert resp.json == {"answer": test_answer, "session": dummy_token}
+
+
+@patch("flask_api.save_audiofile")
+@patch("flask_api.create_filename", return_value="test_filename")
+@patch("flask_api.WakeWordValidator")
+@patch("flask_api.WakeWordFormatter")
+@patch("flask_api.db")
+def test_new_data_wakeword(mock_db, mock_formatter, mock_validator, mock_create_filename, mock_save_audiofile, client):
+    mock_formatter_instance = Mock()
+    mock_formatter_instance.format.return_value = {"filename": "dummy"}
+    mock_formatter.return_value = mock_formatter_instance
+
+    resp = client.post(
+        '/new_data/wakeword',
+        data={"test": "foo", 'wav_file': (BytesIO(b'dummyText'), 'dummyfile.txt')})
+
+    # Verify that db client was told to save data, and that the newly generated filename was returned
+    mock_db.save_audio_sample_meta_data.assert_called_once()
+    assert resp.data == b"test_filename"
+
+
+@patch("flask_api.WakeWordValidator")
+def test_new_data_wakeword_validator_issues(mock_validator, client):
+    mock_validator_instance = Mock()
+    mock_validator_instance.fix.side_effect = WakeWordValidatorError(TEST_ERROR)
+    mock_validator.return_value = mock_validator_instance
+
+    # Verify that the client will catch and throw an error if the validator fails
+    resp = client.post('/new_data/wakeword', data={"dummy1": "dummy2"})
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == TEST_ERROR.encode()
+
+
+@patch("flask_api.save_audiofile")
+@patch("flask_api.create_filename", return_value="test_filename")
+@patch("flask_api.WakeWordValidator")
+@patch("flask_api.WakeWordFormatter")
+@patch("flask_api.db")
+def test_new_data_wakeword_db_error(mock_db, mock_formatter, mock_validator, mock_create_filename,
+                                    mock_save_audiofile, client):
+    mock_formatter_instance = Mock()
+    mock_formatter_instance.format.return_value = {"filename": "dummy"}
+    mock_formatter.return_value = mock_formatter_instance
+
+    # Verify that the client will catch and throw an error for specific exceptions
+    mock_db.save_audio_sample_meta_data.side_effect = BadDictionaryKeyError(TEST_ERROR)
+    resp = client.post(
+        '/new_data/wakeword',
+        data={"test": "foo", 'wav_file': (BytesIO(b'dummyText'), 'dummyfile.txt')})
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == TEST_ERROR.encode()
+
+    mock_db.save_audio_sample_meta_data.side_effect = BadDictionaryValueError(TEST_ERROR)
+    resp = client.post(
+        '/new_data/wakeword',
+        data={"test": "foo", 'wav_file': (BytesIO(b'dummyText'), 'dummyfile.txt')})
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == TEST_ERROR.encode()
+
+    mock_db.save_audio_sample_meta_data.side_effect = NimbusDatabaseError(TEST_ERROR)
+    resp = client.post(
+        '/new_data/wakeword',
+        data={"test": "foo", 'wav_file': (BytesIO(b'dummyText'), 'dummyfile.txt')})
+    assert resp.status_code == BAD_REQUEST
+    assert resp.data == TEST_ERROR.encode()


### PR DESCRIPTION
## What's New?
*Adds unit tests for the /new_data/wakeword endpoint. Figuring out how to unittest this in Python was a little strange, but now that this is done, the other endpoints should come much easier.
* Changed FormatterValidatorError to WakeWordValidatorError in flask app
* Adjusts unit tests to mock global variables rather than the constructors

## Type of change (pick-one)
- [x] New tests

## How Has This Been Tested?
`sh run_tests.sh`
![image](https://user-images.githubusercontent.com/13087024/81511289-28484f80-92cd-11ea-806d-aa65a0c9f9dc.png)

We've hit a pretty nice goal: 60% overall coverage!
![image](https://user-images.githubusercontent.com/13087024/81511319-53cb3a00-92cd-11ea-84cf-1a8f23f3d5ff.png)

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [x] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [x] I added my tests to the `/tests` directory

- [x] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
