### PR TITLE
Pull out EXPECTED_KEYS_BY_ENTITY and update tests

### DIFF
--- a/Entity/ExpectedKeys.py
+++ b/Entity/ExpectedKeys.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+This module holds the expected keys for each Entity type.
+"""
+
+from Entity.AudioSampleMetaData import AudioSampleMetaData, NoiseLevel
+from Entity.Calendars import Calendars
+from Entity.Clubs import Clubs
+from Entity.Courses import Courses
+from Entity.Locations import Locations
+from Entity.QueryFeedback import QueryFeedback
+from Entity.QuestionAnswerPair import QuestionAnswerPair, AnswerType
+from Entity.QuestionLog import QuestionLog
+from Entity.OfficeHours import OfficeHours
+from Entity.Professors import ProfessorsProperties
+from Entity.Profs import Profs
+from Entity.Professors import Professors
+from Entity.ProfessorSectionView import ProfessorSectionView
+from Entity.Sections import Sections, SectionType
+
+# Supported Entities only and their expected keys
+EXPECTED_KEYS_BY_ENTITY = {
+    AudioSampleMetaData: [
+        "is_wake_word",
+        "first_name",
+        "last_name",
+        "gender",
+        "noise_level",
+        "location",
+        "tone",
+        "timestamp",
+        "username",
+        "audio_file_id",
+        "script",
+        "emphasis"
+    ],
+    Clubs: [
+        "club_name",
+        "types",
+        "desc",
+        "contact_email",
+        "contact_email_2",
+        "contact_person",
+        "contact_phone",
+        "box",
+        "advisor",
+        "affiliation",
+    ],
+    Calendars: [
+        'date',
+        'day',
+        'month',
+        'year',
+        'raw_events_text',
+    ],
+    Courses: [
+        'dept',
+        'course_num',
+        'course_name',
+        'units',
+        'prerequisites',
+        'corequisites',
+        'concurrent',
+        'recommended',
+        'terms_offered',
+        'ge_areas',
+        'desc',
+    ],
+    Locations: [
+        "building_number", 
+        "name", 
+        "longitude", 
+        "latitude",
+    ],
+    Sections: [
+        "section_name",
+        "instructor",
+        "alias",
+        "title",
+        "phone",
+        "office",
+        "type",
+        "days",
+        "start",
+        "end",
+        "location",
+        "department",
+    ],
+    QuestionAnswerPair: [
+        "can_we_answer",
+        "verified",
+        "answer_type",
+        "question_format",
+        "answer_format",
+    ],
+    QueryFeedback: [
+        "question", 
+        "answer", 
+        "answer_type", 
+        "timestamp",
+    ],
+    QuestionLog: [
+        "question", 
+        "timestamp",
+    ],
+    Professors: [
+        "first_name",
+        "last_name",
+        "phone_number",
+        "email",
+        "research_interests",
+        "office",
+    ]
+}

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -35,6 +35,7 @@ from Entity.Professors import Professors
 from Entity.ProfessorSectionView import ProfessorSectionView
 from Entity.OfficeHours import OfficeHours
 from Entity.QuestionLog import QuestionLog
+from Entity.ExpectedKeys import EXPECTED_KEYS_BY_ENTITY
 
 from fuzzywuzzy import fuzz
 
@@ -58,86 +59,6 @@ default_tag_column_dict = {
     Clubs: {"club_name"},
     Sections: {"section_name"},
     ProfessorSectionView: {"first_name", "last_name"},
-}
-
-EXPECTED_KEYS_BY_ENTITY = {
-    AudioSampleMetaData: [
-        "is_wake_word",
-        "first_name",
-        "last_name",
-        "gender",
-        "noise_level",
-        "location",
-        "tone",
-        "timestamp",
-        "username",
-        "audio_file_id",
-        "script",
-        "emphasis"
-    ],
-    Clubs: [
-        "club_name",
-        "types",
-        "desc",
-        "contact_email",
-        "contact_email_2",
-        "contact_person",
-        "contact_phone",
-        "box",
-        "advisor",
-        "affiliation",
-    ],
-    Calendars: [
-        'date',
-        'day',
-        'month',
-        'year',
-        'raw_events_text',
-    ],
-    Courses: [
-        'dept',
-        'course_num',
-        'course_name',
-        'units',
-        'prerequisites',
-        'corequisites',
-        'concurrent',
-        'recommended',
-        'terms_offered',
-        'ge_areas',
-        'desc',
-    ],
-    Locations: ["building_number", "name", "longitude", "latitude"],
-    Sections: [
-        "section_name",
-        "instructor",
-        "alias",
-        "title",
-        "phone",
-        "office",
-        "type",
-        "days",
-        "start",
-        "end",
-        "location",
-        "department",
-    ],
-    QuestionAnswerPair: [
-        "can_we_answer",
-        "verified",
-        "answer_type",
-        "question_format",
-        "answer_format",
-    ],
-    QueryFeedback: ["question", "answer", "answer_type", "timestamp",],
-    Professors: ["first_name",
-                 "last_name",
-                 "phone_number",
-                 "email",
-                 "research_interests",
-                 "office",
-    ],
-    QuestionLog: ["question", "timestamp"],
 }
 
 
@@ -387,17 +308,19 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
 
     def __init__(self, config_file: str = "config.json") -> None:
         self.engine = self._create_engine(config_file)
-        self.Clubs = Clubs
-        self.Sections = Sections
-        self.Calendars = Calendars
-        self.Courses = Courses
-        self.Profs = Profs
         self.AudioSampleMetaData = AudioSampleMetaData
+        self.Calendars = Calendars
+        self.Clubs = Clubs
+        self.Courses = Courses
         self.Locations = Locations
-        self.ProfessorSectionView = ProfessorSectionView
         self.OfficeHours = OfficeHours
-        self.QuestionAnswerPair = QuestionAnswerPair
+        self.ProfessorSectionView = ProfessorSectionView
+        self.Profs = Profs
         self.Professors = Professors
+        self.QueryFeedback = QueryFeedback
+        self.QuestionAnswerPair = QuestionAnswerPair
+        self.QuestionLog = QuestionLog
+        self.Sections = Sections
         self.inspector = inspect(self.engine)
         self._create_database_session()
         print("initialized NimbusMySQLAlchemy")
@@ -462,15 +385,9 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
             print(f"<{table_name}> created")
             return
 
-        __safe_create(self.Clubs)
-        __safe_create(self.Sections)
-        __safe_create(self.Calendars)
-        __safe_create(self.Courses)
-        __safe_create(self.AudioSampleMetaData)
-        __safe_create(self.Locations)
-        __safe_create(self.OfficeHours)
-        __safe_create(self.QuestionAnswerPair)
-        __safe_create(self.Professors)
+        for entity_type in EXPECTED_KEYS_BY_ENTITY.keys():
+            __safe_create(getattr(self, entity_type.__name__));
+
 
     def _create_database_session(self):
         Session = sessionmaker(bind=self.engine)

--- a/tests/test_database_wrapper.py
+++ b/tests/test_database_wrapper.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import sys
 
 from database_wrapper import (
     NimbusMySQLAlchemy,
@@ -11,21 +12,13 @@ from database_wrapper import (
     UnsupportedDatabaseError,
     BadConfigFileError,
 )
+from Entity.ExpectedKeys import EXPECTED_KEYS_BY_ENTITY
 from mock import patch, Mock
 from .MockEntity import MockEntity
 from .MockViewEntity import MockViewEntity
 
 
-ENTITY_TYPES = [
-    "AudioSampleMetaData",
-    "Calendars",
-    "Courses",
-    "Locations",
-    "QuestionAnswerPair",
-    "Professors",
-    "Clubs",
-    "Sections",
-]
+ENTITY_TYPES = [i.__name__ for i in EXPECTED_KEYS_BY_ENTITY.keys()]
 
 MOCK_ENTITY_DATA_DICT = {
     "value_one": "test1",
@@ -117,7 +110,11 @@ def test_create_all_tables(mock_create_engine):
 
     # Verify that each Entity had .create() called on it once.
     for entity_type in ENTITY_TYPES:
-        getattr(test_db, entity_type).__table__.create.assert_called_once()
+        try:
+            getattr(test_db, entity_type).__table__.create.assert_called_once()
+        except AssertionError as e: 
+            print("{} table was not created".format(entity_type), file=sys.stderr);
+            raise e
 
 
 @patch.object(NimbusMySQLAlchemy, "_create_engine")


### PR DESCRIPTION
## What's New?
* Pull out `EXPECTED_KEYS_BY_ENTITY` to its own module for cleanliness
* Update tests to use the Entity keys in the EXPECTED_KEYS_BY_ENTITY for more robust testing

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
`sh run_tests.sh`
![image](https://user-images.githubusercontent.com/13087024/83364005-b9519a00-a352-11ea-8637-eac82cd3f178.png)


## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [x] I added my tests to the `/tests` directory

- [x] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
