### PR TITLE
Entity Token Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,7 @@ venv.bak/
 .api.py
 .db_config.py
 db_config.py
-.vscode/settings.json
+.vscode/*
 config.json
 credentials.json
 folder_id.txt

--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -1,0 +1,54 @@
+class Entity:
+    """
+    An instance of an element in the Nimbus SQL Database.
+    """
+
+    __mapper_args__ = {
+        "exclude_properties": ["validate", "format", "metadata", "get_data"]
+    }
+
+    def __init__(self, data):
+        print("constructed Entity")
+        self.validate(data)
+        formatted_data = self.format(data)
+        for key in formatted_data:
+            setattr(self, key, formatted_data[key])
+
+    def validate(self, data):
+        """
+        Checks if data has all required fields. Raises exception if data is misformed. 
+        Note that you can have multiple validators to take in different data schemas.
+        Parameters
+        ----------
+        `data:dict` Data to be validated, representing a single instance of the entity . 
+        Raises
+        -------
+        Some type of Exception based on the problem with the data
+        """
+        pass
+
+    def format(self, data) -> dict:
+        """
+        Casts data to correct types, assigns keys to match object.
+        Parameters
+        ----------
+        `data:dict` Data to be formatted, representing a single instance of the entity. 
+        Returns
+        -------
+        `dict` new data object which has been formatted.
+        """
+        pass
+
+    def get_data(self):
+        """
+        Returns all fields that are related to table data.
+        """
+        pass
+
+    def __repr__(self):
+        D = self.__dict__
+        attributes = [
+            f"{k}={D.get(k)}" for k in self.__dir__() if not k.startswith("_")
+        ]
+        attributes_string = ", ".join(attributes)
+        return f"{self.__class__.__name__}({attributes_string})"

--- a/Entity/EntityToken.py
+++ b/Entity/EntityToken.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, String, Text
+from sqlalchemy.ext.declarative import declarative_base
+from Entity.Entity import Entity
+
+Base = declarative_base()
+
+
+class EntityToken(Entity, Base):
+    __tablename__ = "EntityTokens"
+    __mapper_args__ = {"concrete": True}
+    id = Column(String(32), primary_key=True)
+    description = Column(Text)
+    name = Column(String(64))
+
+    def validate(self, data):
+        required_fields = ["id", "description", "name"]
+        for field in required_fields:
+            if field not in data:
+                raise Exception(
+                    f"Required field `{field}` wasn't provided. Please provide the following[{required_fields}]"
+                )
+
+    def format(self, data) -> dict:
+        form = data.copy()
+        for key in form:
+            form[key] = str(form[key])
+        return form
+
+    def get_data(self):
+        return {"name": self.name, "description": self.description, "id": self.id}

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -651,9 +651,12 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         if not isinstance(entity, Entity):
             return False
         print("Saving to database: {}...".format(entity))
-        self.session.add(entity)
-        self.session.commit()
-        print("{}Saved!\n{}".format(GREEN_COLOR_CODE, RESET_COLOR_CODE))
+        try:
+            self.session.add(entity)
+            self.session.commit()
+            print("{}Saved!\n{}".format(GREEN_COLOR_CODE, RESET_COLOR_CODE))
+        except:
+            return False
         return True
 
     def insert_entity(self, entity_type, data_dict: dict) -> bool:

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -21,6 +21,7 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
+from Entity.Entity import Entity
 from Entity.AudioSampleMetaData import AudioSampleMetaData, NoiseLevel
 from Entity.Calendars import Calendars
 from Entity.Courses import Courses
@@ -46,7 +47,12 @@ CYAN_COLOR_CODE = "\033[96m"
 RESET_COLOR_CODE = "\033[00m"
 
 UNION_ENTITIES = Union[
-    AudioSampleMetaData, Calendars, Courses, Profs, QuestionAnswerPair, ProfessorSectionView
+    AudioSampleMetaData,
+    Calendars,
+    Courses,
+    Profs,
+    QuestionAnswerPair,
+    ProfessorSectionView,
 ]
 UNION_PROPERTIES = Union[ProfessorsProperties]
 
@@ -73,7 +79,7 @@ EXPECTED_KEYS_BY_ENTITY = {
         "username",
         "audio_file_id",
         "script",
-        "emphasis"
+        "emphasis",
     ],
     Clubs: [
         "club_name",
@@ -87,25 +93,19 @@ EXPECTED_KEYS_BY_ENTITY = {
         "advisor",
         "affiliation",
     ],
-    Calendars: [
-        'date',
-        'day',
-        'month',
-        'year',
-        'raw_events_text',
-    ],
+    Calendars: ["date", "day", "month", "year", "raw_events_text",],
     Courses: [
-        'dept',
-        'course_num',
-        'course_name',
-        'units',
-        'prerequisites',
-        'corequisites',
-        'concurrent',
-        'recommended',
-        'terms_offered',
-        'ge_areas',
-        'desc',
+        "dept",
+        "course_num",
+        "course_name",
+        "units",
+        "prerequisites",
+        "corequisites",
+        "concurrent",
+        "recommended",
+        "terms_offered",
+        "ge_areas",
+        "desc",
     ],
     Locations: ["building_number", "name", "longitude", "latitude"],
     Sections: [
@@ -130,12 +130,13 @@ EXPECTED_KEYS_BY_ENTITY = {
         "answer_format",
     ],
     QueryFeedback: ["question", "answer", "answer_type", "timestamp",],
-    Professors: ["first_name",
-                 "last_name",
-                 "phone_number",
-                 "email",
-                 "research_interests",
-                 "office",
+    Professors: [
+        "first_name",
+        "last_name",
+        "phone_number",
+        "email",
+        "research_interests",
+        "office",
     ],
     QuestionLog: ["question", "timestamp"],
 }
@@ -377,7 +378,6 @@ def raises_database_error(func):
             # HINT: security always wins, so try to catch the EXACT exception
             raise e
 
-
     return wrapper
 
 
@@ -577,11 +577,13 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         print(sorted_results)
         return sorted_results
 
-    def get_property_from_entity(self,
+    def get_property_from_entity(
+        self,
         prop: str,
         entity: UNION_ENTITIES,
         identifier: str,
-        tag_column_map: dict = default_tag_column_dict):
+        tag_column_map: dict = default_tag_column_dict,
+    ):
 
         props = self._get_property_from_entity(prop, entity, identifier, tag_column_map)
         if props is None:
@@ -634,6 +636,26 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         self.validate_input_keys(data_dict, EXPECTED_KEYS_BY_ENTITY[entity_type])
         return data_dict
 
+    def add_entity(self, entity) -> bool:
+        """
+        A simplified version of insert_entity that relies on the entity performing its own formatting in the constructor call.
+        Parameters
+        ---------
+        `entity - Entity` an initialized entity object to be added to the database.
+
+        Returns
+        -------
+        `bool` whether entity was successfully added.
+        """
+        # Don't post if the entity doesn't abide by the rules of the Entity superclass
+        if not isinstance(entity, Entity):
+            return False
+        print("Saving to database: {}...".format(entity))
+        self.session.add(entity)
+        self.session.commit()
+        print("{}Saved!\n{}".format(GREEN_COLOR_CODE, RESET_COLOR_CODE))
+        return True
+
     def insert_entity(self, entity_type, data_dict: dict) -> bool:
         """
         Inserts an entity into the database. The keys of data_dict should follow camelCase
@@ -668,7 +690,6 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
                 CYAN_COLOR_CODE, entity_attributes["__tablename__"], RESET_COLOR_CODE
             )
         )
-
 
         # Grab the entity class fields by cleaning the attributes dictionary
         # Note: Make sure you don't label any important data fields with underscores in the front or back!
@@ -882,7 +903,6 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
             "timestamp": datetime.datetime.now(),
         }
 
-
     def __del__(self):
         print("NimbusMySQLAlchemy closed")
 
@@ -918,10 +938,7 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
             "timestamp": feedback["timestamp"],
         }
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     db = NimbusMySQLAlchemy()
-    print(
-        db._get_property_from_entity("section_name",
-                                     ProfessorSectionView,
-                                     "Braun")
-    )
+    print(db._get_property_from_entity("section_name", ProfessorSectionView, "Braun"))

--- a/flask_api.py
+++ b/flask_api.py
@@ -474,9 +474,8 @@ def add_entity_token():
         new_token = EntityToken(data)
     except Exception as ex:
         return ex.args[0], BAD_REQUEST
-    try:
-        db.add_entity(new_token)
-    except:
+    token_added = db.add_entity(new_token)
+    if not token_added:
         return "Could not add token", BAD_REQUEST
     return "Added Token", SUCCESS
 

--- a/flask_api.py
+++ b/flask_api.py
@@ -39,6 +39,8 @@ from Entity.QuestionAnswerPair import QuestionAnswerPair
 from Entity.QueryFeedback import QueryFeedback
 from Entity.QuestionLog import QuestionLog
 
+from Entity.EntityToken import EntityToken
+
 from nimbus import Nimbus
 
 BAD_REQUEST = 400
@@ -90,7 +92,7 @@ def handle_database_error(error):
         # reinit the database
         init_nimbus_db()
     else:
-        # we *probably* have a bad session - try and roll it back, 
+        # we *probably* have a bad session - try and roll it back,
         # then create a new database connection.
         db.session.rollback()
         db.session.close()
@@ -140,7 +142,6 @@ def handle_question():
     except (Exception) as e:
         print("Could not store question upon user ask: ", str(e))
 
-
     response = {"answer": nimbus.answer_question(question)}
 
     if "session" in request_body:
@@ -155,8 +156,11 @@ def handle_question():
 def save_a_recording():
     """Given the audio metadata & audio file, resamples it, saves to storage.
     """
-    if("wav_file" not in request.files):
-         return "Please provide an audio file under the key 'wav_file' in your FormData", BAD_REQUEST
+    if "wav_file" not in request.files:
+        return (
+            "Please provide an audio file under the key 'wav_file' in your FormData",
+            BAD_REQUEST,
+        )
     validator = WakeWordValidator()
     formatter = WakeWordFormatter()
     data = request.form
@@ -169,9 +173,9 @@ def save_a_recording():
     formatted_data = formatter.format(data)
     filename = create_filename(formatted_data)
     try:
-         file_id = save_audiofile(filename, request.files["wav_file"])
+        file_id = save_audiofile(filename, request.files["wav_file"])
     except Exception as err:
-         return f"Failed to save audio file because... {err}", BAD_REQUEST
+        return f"Failed to save audio file because... {err}", BAD_REQUEST
 
     formatted_data["audio_file_id"] = file_id
 
@@ -301,7 +305,7 @@ def save_courses():
 
     for course in data["courses"]:
         try:
-            db.update_entity(Courses, course, ['dept', 'course_num'])
+            db.update_entity(Courses, course, ["dept", "course_num"])
         except BadDictionaryKeyError as e:
             return str(e), BAD_REQUEST
         except BadDictionaryValueError as e:
@@ -315,6 +319,7 @@ def save_courses():
             raise e
 
     return "SUCCESS"
+
 
 @app.route("/new_data/sections", methods=["POST"])
 def save_sections():
@@ -341,6 +346,7 @@ def save_sections():
 
     return "SUCCESS"
 
+
 @app.route("/new_data/clubs", methods=["POST"])
 def save_clubs():
     """
@@ -352,7 +358,7 @@ def save_clubs():
 
     for club in data["clubs"]:
         try:
-            db.update_entity(Clubs, club, ['club_name'])
+            db.update_entity(Clubs, club, ["club_name"])
         except BadDictionaryKeyError as e:
             return str(e), BAD_REQUEST
         except BadDictionaryValueError as e:
@@ -379,7 +385,7 @@ def save_locations():
 
     for location in data["locations"]:
         try:
-            db.update_entity(Locations, location, ['longitude', 'latitude'])
+            db.update_entity(Locations, location, ["longitude", "latitude"])
         except BadDictionaryKeyError as e:
             return str(e), BAD_REQUEST
         except BadDictionaryValueError as e:
@@ -433,7 +439,7 @@ def save_calendars():
 
     for calendar in data["calendars"]:
         try:
-            db.update_entity(Calendars, calendar, ['date', 'raw_events_text'])
+            db.update_entity(Calendars, calendar, ["date", "raw_events_text"])
         except BadDictionaryKeyError as e:
             return str(e), BAD_REQUEST
         except BadDictionaryValueError as e:
@@ -447,6 +453,32 @@ def save_calendars():
             raise e
 
     return "SUCCESS"
+
+
+@app.route("/schema/entity_tokens", methods=["GET"])
+def get_entity_tokens():
+    init_nimbus_db()
+    try:
+        identifiers = db.session.query(EntityToken).all()
+    except:
+        return "Could not fetch at this time", BAD_REQUEST
+    data = list(map(lambda token: token.get_data(), identifiers))
+    return jsonify(data)
+
+
+@app.route("/schema/entity_tokens", methods=["POST"])
+def add_entity_token():
+    init_nimbus_db()
+    data = request.get_json()
+    try:
+        new_token = EntityToken(data)
+    except Exception as ex:
+        return ex.args[0], BAD_REQUEST
+    try:
+        db.add_entity(new_token)
+    except:
+        return "Could not add token", BAD_REQUEST
+    return "Added Token", SUCCESS
 
 
 def create_filename(form):
@@ -464,8 +496,7 @@ def create_filename(form):
         "timestamp",
         "username",
     ]
-    values = list(
-        map(lambda key: str(form[key]).lower().replace(" ", "-"), order))
+    values = list(map(lambda key: str(form[key]).lower().replace(" ", "-"), order))
     return "_".join(values) + ".wav"
 
 
@@ -485,10 +516,10 @@ def process_office_hours(current_prof: dict, db: NimbusMySQLAlchemy):
 
     # Check if the current entity is already within the database
     if (
-            db.get_property_from_entity(
-                prop="Name", entity=entity_type, identifier=current_prof["Name"]
-            )
-            != None
+        db.get_property_from_entity(
+            prop="Name", entity=entity_type, identifier=current_prof["Name"]
+        )
+        != None
     ):
 
         update_office_hours = True
@@ -550,8 +581,7 @@ def process_office_hours(current_prof: dict, db: NimbusMySQLAlchemy):
     # Update the entity properties if the entity already exists
     if update_office_hours == True:
         db.update_entity(
-            entity_type=entity_type, data_dict=sql_data, filter_fields=[
-                "Email"]
+            entity_type=entity_type, data_dict=sql_data, filter_fields=["Email"]
         )
 
     # Otherwise, add the entity to the database
@@ -612,5 +642,4 @@ def convert_to_mfcc():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", debug=gunicorn_config.DEBUG_MODE,
-            port=gunicorn_config.PORT)
+    app.run(host="0.0.0.0", debug=gunicorn_config.DEBUG_MODE, port=gunicorn_config.PORT)


### PR DESCRIPTION
## What's New?
Currently, there isn't a centralized source of information for the Entity tokens used in the QuestionAnswerPairs. For example:
```
Where is [SECRET_HIDEOUT]?
```
While this is totally hilarious as someone who was there for the inside joke, it won't be as intuitive for those who just joined the club.

The API is centered around the endpoint: ``schema/entity_tokens``
### It has 2 functionalities
#### ``GET`` Pulls down all approved QAPair tokens
Requires no arguments
Returns an array of all tokens:
```
[
{name: "Location", id: "SECRET_HIDEOUT", description: "A place on campus"}
]
```
#### ``POST`` Adds a new key to the ``EntityTokens`` table
Post json body format: ``{name: "Location", id: "SECRET_HIDEOUT", description: "A place on campus"}``

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I used Postman to test both endpoints. You can find both requests in the CSAI Postman ``CSAI Web`` folder:
- Get Entity Tokens
- Add Entity Token