### PR TITLE
REST hooks for validator app to update and delete QAPairs

### DIFF
--- a/Entity/Entity.py
+++ b/Entity/Entity.py
@@ -4,7 +4,14 @@ class Entity:
     """
 
     __mapper_args__ = {
-        "exclude_properties": ["validate", "format", "metadata", "get_data"]
+        "exclude_properties": [
+            "validate",
+            "format",
+            "metadata",
+            "get_data",
+            "validators",
+            "formatters",
+        ]
     }
 
     def __init__(self, data):
@@ -44,6 +51,14 @@ class Entity:
         Returns all fields that are related to table data.
         """
         pass
+
+    def update(self, data: dict) -> bool:
+        """
+        Updates properties of the entity with the values in the `data` dict.
+        Parameters
+        ----------
+        `data:dict` A subset of entity's properties to update. 
+        """
 
     def __repr__(self):
         D = self.__dict__

--- a/Entity/QuestionAnswerPair.py
+++ b/Entity/QuestionAnswerPair.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, Text, Enum, Boolean
 from sqlalchemy.ext.declarative import declarative_base
+from Entity.Entity import Entity
 import enum
 
 # This is the way SQLAlchemy initializes their special classes
@@ -18,7 +19,7 @@ class AnswerType(enum.Enum):
     other = 4  # something difficult or unknown.
 
 
-class QuestionAnswerPair(Base):
+class QuestionAnswerPair(Entity, Base):
     __tablename__ = "QuestionAnswerPair"
     id = Column(Integer, primary_key=True)
     # SQLAlchemy resolves Boolean to TINYINT within MYSQL
@@ -28,6 +29,108 @@ class QuestionAnswerPair(Base):
     question_format = Column(Text)
     answer_format = Column(Text)
     is_view = False
+
+    validators = {
+        "question": {
+            "validate": lambda data: "question" in data
+            and type(data["question"]) == str,
+            "error_message": "Question wasn't provided as a string.",
+        },
+        "answer": {
+            "validate": lambda data: "answer" in data and type(data["answer"]) == str,
+            "error_message": "Answer wasn't provided as a string.",
+        },
+        "type": {
+            "validate": lambda data: "type" in data
+            and data["type"].lower() in [t.name for t in AnswerType],
+            "error_message": "Provided QAPair type is not provided or not supported.",
+        },
+        "verified": {
+            "validate": lambda data: type(data["verified"]) == bool
+            or data["verified"] in ["true", "false"],
+            "error_message": "Verified is not a boolean-like value.",
+        },
+        "isAnswerable": {
+            "validate": lambda data: type(data["isAnswerable"]) == bool
+            or data["isAnswerable"] in ["true", "false"],
+            "error_message": "isAnswerable is not a boolean-like value.",
+        },
+        "id": {
+            "validate": lambda data: type(data["id"]) == int or data["id"].is_digit(),
+            "error_message": "id is not a valid type or not provided.",
+        },
+    }
+
+    formatters = {
+        "question": lambda form: ("question_format", form["question"]),
+        "answer": lambda form: ("answer_format", form["answer"]),
+        "type": lambda form: ("answer_type", AnswerType[form["type"].lower()])
+        if "type" in form
+        else AnswerType.other,
+        "isAnswerable": lambda form: (
+            "can_we_answer",
+            form["isAnswerable"]
+            if type(form["isAnswerable"]) == bool
+            else form["isAnswerable"] == "true",
+        ),
+        "verified": lambda form: (
+            "verified",
+            form["verified"]
+            if type(form["verified"]) == bool
+            else form["verified"] == "true",
+        ),
+        "id": lambda form: ("id", int(form["id"])),
+    }
+
+    def validate(self, data):
+        required_fields = ["question", "answer", "type"]
+        optional_fields = ["isAnswerable", "verified"]
+        for field in required_fields:
+            validator = self.validators[field]
+            valid = validator["validate"](data)
+            if not valid:
+                raise Exception(validator["error_message"])
+        for field in optional_fields:
+            if field not in data:
+                continue
+            validator = self.validators[field]
+            valid = validator["validate"](data)
+            if not valid:
+                raise Exception(validator["error_message"])
+
+    def format(self, data) -> dict:
+        form = {}
+        for field, val in data.items():
+            if field not in self.formatters:
+                continue
+            key, value = self.formatters[field](form)
+            form[key] = value
+        return form
+
+    def update(self, data: dict) -> bool:
+        try:
+            for key, value in data.items():
+                # validate
+                validator = self.validators[key]
+                valid = validator["validate"](data)
+                if not valid:
+                    raise Exception(validator["error_message"])
+                # format
+                name, value = self.formatters[key](data)
+                # update
+                setattr(self, name, value)
+        except Exception:
+            return False
+        return True
+
+    def get_data(self):
+        return {
+            "can_we_answer": self.can_we_answer,
+            "verified": self.verified,
+            "answer_type": self.answer_type,
+            "question_format": self.question_format,
+            "answer_format": self.answer_format,
+        }
 
     def __repr__(self):
         """

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -744,6 +744,18 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
         Returns:
             True if all is good, else False
         """
+
+        if issubclass(entity_type, Entity):
+            if "id" not in data_dict:
+                raise BadDictionaryKeyError(
+                    "Include an 'id' field so the element to update can be identified."
+                )
+            updated_entity = self.session.query(entity_type).get(data_dict["id"])
+            updated = updated_entity.update(data_dict)
+            if not updated:
+                return False
+            self.session.commit()
+            return True
         # Initialize dummy entity to check if it's a View
         dummy_entity = entity_type()
         if dummy_entity.is_view:
@@ -869,6 +881,26 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
             raise BadDictionaryValueError(msg)
 
         return data_dict
+
+    def delete_entity(self, entity_type: Entity, identifier) -> bool:
+        """
+        Deletes entity with matching identifier from its table.
+        Parameters
+        ----------
+        `entity_type:Entity` The class of entity. This is used to relate the identifier to a specific table.
+
+        `identifier`: The unique `primary_key` of the desired entity.
+        Returns
+        -------
+        `bool` Whether the operation was successfully completed.
+        """
+        try:
+            target_entity = self.session.query(entity_type).get(identifier)
+            self.session.delete(target_entity)
+            self.session.commit()
+        except:
+            return False
+        return True
 
     def format_query_phrase_dict(self, phrases: dict) -> dict:
         """

--- a/flask_api.py
+++ b/flask_api.py
@@ -259,6 +259,49 @@ def save_query_phrase():
         return "An error was encountered while saving to database", SERVER_ERROR
 
 
+@app.route("/new_data/update_phrase", methods=["POST"])
+def update_query_phrase():
+    init_nimbus_db()
+    data = request.get_json()
+    try:
+        updated = db.update_entity(QuestionAnswerPair, data, [])
+    except (BadDictionaryKeyError, BadDictionaryValueError) as e:
+        return str(e), BAD_REQUEST
+    except NimbusDatabaseError as e:
+        return str(e), SERVER_ERROR
+    except Exception as e:
+        raise e
+
+    return (
+        ("Phrase updated!", SUCCESS)
+        if updated
+        else ("Failed to update phrase", SERVER_ERROR)
+    )
+
+
+@app.route("/new_data/delete_phrase", methods=["POST"])
+def delete_query_phrase():
+    init_nimbus_db()
+    data = request.get_json()
+    if "id" not in data or type(data["id"]) != int:
+        return "Please provide 'id' as an integer"
+    identifier = data["id"]
+    try:
+        deleted = db.delete_entity(QuestionAnswerPair, identifier)
+    except (BadDictionaryKeyError, BadDictionaryValueError) as e:
+        return str(e), BAD_REQUEST
+    except NimbusDatabaseError as e:
+        return str(e), SERVER_ERROR
+    except Exception as e:
+        raise e
+
+    return (
+        ("Phrase deleted!", SUCCESS)
+        if deleted
+        else ("Failed to delete phrase", SERVER_ERROR)
+    )
+
+
 @app.route("/new_data/feedback", methods=["POST"])
 def save_feedback():
     validator = FeedbackValidator()


### PR DESCRIPTION
## What's New?
The web team is building a Nimbus validator to ensure high quality QAPairs. We need 2 api endpoints to make the app work:
- update: fix aspects of a QAPair during validation.
- delete: erase a QA Pair that is beyond saving.

In the process of making these two endpoints, I made the following additional changes:
- added a general purpose ``delete_entity`` function.
- modified the ``update_entity`` function to work with the ``Entity`` interface #174.
- modified ``QuestionAnswerPair`` class to inherit from ``Entity``.
- added validation, formatting and updating functionality to ``QuestionAnswerPair``.
## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I checked updating all fields and deleting the test row with Postman.
The following requests can be found in the `CSAI Web` team folder:
- **UpdateQAPair** with endpoint ``new_data/update_phrase``.
- **DeleteQAPair** with endpoint ``new_data/delete_phrase``.

**I won't be able to make changes after June 14, so I leave it up to you all to carry this through.**
You can still reach out to me with general questions.