### PR TITLE
Created GET route for unvalidated QA pairs

### DIFF
--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -408,14 +408,12 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
 
         return result
 
-    # TODO:need to figure out how to turn answerType object into string
-    def get_all_unvalidated_qa_data(self):
+    def get_all_unvalidated_qa_data(self, numQueries: int):
         qa = QuestionAnswerPair
 
         query_session = self.session.query(
-            qa.id, qa.can_we_answer, qa.question_format, qa.answer_format, qa.verified
-        ).filter(qa.verified == 0)
-        # .limit(10)
+            qa.id, qa.can_we_answer, qa.question_format, qa.answer_format, qa.verified, qa.answer_type
+        ).filter(qa.verified == 0).limit(numQueries)
         result = query_session.all()
         unvalidated_qa_pairs = []
         for qa_pair in result:
@@ -424,11 +422,12 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
                 "can_we_answer": qa_pair[1],
                 "question_format": qa_pair[2],
                 "answer_format": qa_pair[3],
-                "verified": qa_pair[4]
+                "verified": qa_pair[4],
+                "answer_type": qa_pair[5].name,
             }
             unvalidated_qa_pairs.append(formatted_QA_pair)
 
-        return {"data": unvalidated_qa_pairs}
+        return unvalidated_qa_pairs
 
     def get_all_answerable_pairs(self):
         qa_entity = QuestionAnswerPair

--- a/database_wrapper.py
+++ b/database_wrapper.py
@@ -408,13 +408,14 @@ class NimbusMySQLAlchemy:  # NimbusMySQLAlchemy(NimbusDatabase):
 
         return result
 
-    def get_all_unvalidated_qa_data(self, numQueries: int):
+    def get_unvalidated_qa_data(self, numQueries: int):
         qa = QuestionAnswerPair
 
         query_session = self.session.query(
             qa.id, qa.can_we_answer, qa.question_format, qa.answer_format, qa.verified, qa.answer_type
         ).filter(qa.verified == 0).limit(numQueries)
         result = query_session.all()
+        print(result)
         unvalidated_qa_pairs = []
         for qa_pair in result:
             formatted_QA_pair = {

--- a/flask_api.py
+++ b/flask_api.py
@@ -43,6 +43,8 @@ from Entity.EntityToken import EntityToken
 
 from nimbus import Nimbus
 
+import json
+
 BAD_REQUEST = 400
 SUCCESS = 200
 SERVER_ERROR = 500
@@ -257,6 +259,18 @@ def save_query_phrase():
         return "Phrase has been saved", SUCCESS
     else:
         return "An error was encountered while saving to database", SERVER_ERROR
+
+
+@app.route("/data/get_phrase", methods=["GET"])
+def get_phrase():
+    init_nimbus_db()
+    try:
+        return {"data": db.get_all_unvalidated_qa_data()}, SUCCESS
+    # TODO: Handle case where nothing is left unvalidated
+    except NimbusDatabaseError as e:
+        return str(e), SERVER_ERROR
+    except Exception as e:
+        raise e
 
 
 @app.route("/new_data/update_phrase", methods=["POST"])
@@ -538,7 +552,8 @@ def create_filename(form):
         "timestamp",
         "username",
     ]
-    values = list(map(lambda key: str(form[key]).lower().replace(" ", "-"), order))
+    values = list(
+        map(lambda key: str(form[key]).lower().replace(" ", "-"), order))
     return "_".join(values) + ".wav"
 
 
@@ -623,7 +638,8 @@ def process_office_hours(current_prof: dict, db: NimbusMySQLAlchemy):
     # Update the entity properties if the entity already exists
     if update_office_hours == True:
         db.update_entity(
-            entity_type=entity_type, data_dict=sql_data, filter_fields=["Email"]
+            entity_type=entity_type, data_dict=sql_data, filter_fields=[
+                "Email"]
         )
 
     # Otherwise, add the entity to the database
@@ -684,4 +700,5 @@ def convert_to_mfcc():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", debug=gunicorn_config.DEBUG_MODE, port=gunicorn_config.PORT)
+    app.run(host="0.0.0.0", debug=gunicorn_config.DEBUG_MODE,
+            port=gunicorn_config.PORT)

--- a/flask_api.py
+++ b/flask_api.py
@@ -266,7 +266,7 @@ def get_phrase(numQueries):
     init_nimbus_db()
     try:
         # if no phrases are unvalidated, will return an empty list
-        return {"data": db.get_all_unvalidated_qa_data(numQueries)}, SUCCESS
+        return {"data": db.get_unvalidated_qa_data(numQueries)}, SUCCESS
     except NimbusDatabaseError as e:
         return str(e), SERVER_ERROR
     except Exception as e:

--- a/flask_api.py
+++ b/flask_api.py
@@ -261,12 +261,12 @@ def save_query_phrase():
         return "An error was encountered while saving to database", SERVER_ERROR
 
 
-@app.route("/data/get_phrase", methods=["GET"])
-def get_phrase():
+@app.route("/data/get_phrase/<numQueries>", methods=["GET"])
+def get_phrase(numQueries):
     init_nimbus_db()
     try:
-        return {"data": db.get_all_unvalidated_qa_data()}, SUCCESS
-    # TODO: Handle case where nothing is left unvalidated
+        # if no phrases are unvalidated, will return an empty list
+        return {"data": db.get_all_unvalidated_qa_data(numQueries)}, SUCCESS
     except NimbusDatabaseError as e:
         return str(e), SERVER_ERROR
     except Exception as e:


### PR DESCRIPTION
#  What's New?
Able to get unvalidated QA pairs from the db which will be used in Nimbus Validator
Created a route and SQL Alchemy function to parse and format the data returned by the query

### Here is the current response of the API call:
GET /data/get_phrase/1
![Screen Shot 2020-07-02 at 4 24 43 PM](https://user-images.githubusercontent.com/44537937/86425356-a0554500-bc80-11ea-9bf9-029bc0a71854.png)
GET /data/get_phrase/4
![Screen Shot 2020-07-02 at 4 24 56 PM](https://user-images.githubusercontent.com/44537937/86425359-a2b79f00-bc80-11ea-869c-f2fda50a32ab.png)


## Fixes #177 

## Type of change (pick-one)
- [ ] Bug fix (_non-breaking change which fixes an issue_)
- [x] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Tested by using the localhost dev version of the server

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
