### PR TITLE
Quick TypeError fix in NLP 👍

### DIFF
--- a/nimbus_nlp/variable_extractor.py
+++ b/nimbus_nlp/variable_extractor.py
@@ -67,7 +67,7 @@ class VariableExtractor:
                             "input question" - input question from the user
                             "normalized question" - variable-replaced question
         """
-        
+
         entity = ""
         tag = ""
         normalized_entity = ""
@@ -77,7 +77,7 @@ class VariableExtractor:
         request = self.get_prediction(sent)
 
         # Input had detected entities
-        if (request.payload != []):
+        if request.payload:
 
             # Obtain the entity in the sentence
             entity = request.payload[0].text_extraction.text_segment.content
@@ -90,7 +90,7 @@ class VariableExtractor:
 
             # Replaces the entity of input question with its corresponding tag
             normalized_question = sent.replace(entity, "[" + tag + "]")
-           
+
         return {
             "entity": entity,
             "tag": tag,


### PR DESCRIPTION
## What's New?
Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

There was a bug in `./api/nimbus_npl/variable_extractor.py`
At line 80 a TypeError was raised:

```
Saving to database: ErrorLog(question=when are Nico office hours?, stacktrace=Traceback (most recent call last):
  File "/home/ethan/Documents/CSAI/new/api/flask_api.py", line 169, in handle_question
    response = {"answer": nimbus.answer_question(question)}
  File "/home/ethan/Documents/CSAI/new/api/nimbus.py", line 33, in answer_question
    ans_dict = self.predict_question(question)
  File "/home/ethan/Documents/CSAI/new/api/nimbus.py", line 65, in predict_question
    nlp_props = self.variable_extractor.extract_variables(question)
  File "/home/ethan/Documents/CSAI/new/api/nimbus_nlp/variable_extractor.py", line 80, in extract_variables
    if (request.payload != []):
TypeError: Can only compare repeated composite fields against other repeated composite fields.
, timestamp=2020-08-01 23:13:02.076835, id=None, is_view=None, metadata=None)...
```
## Solution

Change:
```
  if (request.payload != []):
```
To:
```
  if request.payload:
```


## Type of change (pick-one)
- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The change allowed for correct responses from the server.

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [ ] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [ ] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
