### PR TITLE
Empty string answers now return None 👍

### DIFF
--- a/QA.py
+++ b/QA.py
@@ -51,7 +51,7 @@ class QA:
     def answer(self, extracted_vars):
         db_data = self.db_query(extracted_vars, self.db)
         answer = self.format_answer(extracted_vars, db_data)
-        return answer
+        return None if answer == '' else answer
 
     def __repr__(self):
         return self.q_format
@@ -181,7 +181,7 @@ def format_prof_office_hours(extracted_vars: Extracted_Vars, db_data: DB_Data):
 
 
 def _format_prof_office_hours(prof: str, days: str):
-    hours = lambda x: x[1]
+    def hours(x): return x[1]
 
     week = []
     for token in days.split(", "):
@@ -284,7 +284,8 @@ def generate_qa_pairs(qa_pairs: Tuple[str, str], db: NimbusMySQLAlchemy):
                     tokens[i] = "{db_" + prop + "}"
                 elif len(subtokens) == 4:
                     ent, prop, table, joiner = subtokens
-                    db_access_fns.append(get_property_list(prop, joiner, table))
+                    db_access_fns.append(
+                        get_property_list(prop, joiner, table))
                     tokens[i] = "{db_" + prop + "}"
 
         o = QA(


### PR DESCRIPTION
## What's New?
I added a quick check to see if the NLP returns an empty string to the answer field. Instead return 'None' when this occurs.

## Fixes #198 

## Type of change (pick-one)
- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_non-breaking change which adds functionality_)
- [ ] Breaking change (_fix or feature that would cause existing functionality to not work as expected_)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I ran the following request, which had initially contained an empty answer:
```
curl --location --request POST 'localhost:8080/ask' --header 'Content-Type: application/json' --data-raw '{ "question": "How would I see Dr. Ventura now?" }'
```
Now, it returns:
```
{
  "answer": "I'm sorry, I understand your question but was unable to find an answer. Please try another question.",
  "session": "SOME_NEW_TOKEN"
}
```

## Checklist (check-all-before-merge)
_formatting help: `- [x]` means "checked' and `- [ ]` means "unchecked"_

- [x] I documented my code according to the [Google Python Style Guide][1]

- [ ] I ran `./build_docs.sh` and the docs look fine

- [ ] I ran `./type_check.sh` and got no errors

- [x] I ran `./format.sh` because it automatically cleans my code for me 😄 

- [ ] I ran `./lint.sh` to check for what "format" missed

- [ ] I added my tests to the `/tests` directory

- [ ] I ran `./run_tests.sh` and all the tests pass

[1]: https://google.github.io/styleguide/pyguide.html
